### PR TITLE
Allow for a custom html template

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -26,9 +26,18 @@ if (projectConfig.webpack && projectConfig.webpack.globals) {
   javaScriptGlobals = new webpack.ProvidePlugin(projectConfig.webpack.globals);
 }
 
+
+// Get html template path
+let template;
+if (!projectConfig.html.template || projectConfig.html.template === 'default') {
+  template = path.join(templatesDir, '/_index.html');
+} else {
+  template = path.join(cwd, projectConfig.html.template);
+}
+
 // Webpack-generated HTML file
 const htmlEntryPoint = new HtmlWebpackPlugin({
-  template: path.join(templatesDir, '/_index.html'),
+  template,
   title: htmlTitle,
   description: htmlDescription,
   mountId: 'root',

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -41,10 +41,18 @@ const uglify = new webpack.optimize.UglifyJsPlugin({
   mangle: true,
 });
 
+// Get html template path
+let template;
+if (!projectConfig.html.template || projectConfig.html.template === 'default') {
+  template = path.join(templatesDir, '/_index.html');
+} else {
+  template = path.join(cwd, projectConfig.html.template);
+}
+
 // Webpack-generated HTML file
 const htmlEntryPoint = new HtmlWebpackPlugin({
   filename: path.join(staticDir, '/index.html'),
-  template: path.join(templatesDir, '/_index.html'),
+  template,
   title: htmlTitle,
   description: htmlDescription,
   mountId: 'root',

--- a/templates/_config.js
+++ b/templates/_config.js
@@ -8,6 +8,7 @@ module.exports = {
     title: 'The Invisible Framework',
     description: 'The Invisible Framework',
     favicon: '',
+    template: 'default',
   },
 
   webpack: {


### PR DESCRIPTION
Some projects need custom html -- it may be useful in some situations to replace the base HTML template at the project level when the user needs more elements than meta tags, etc.