### PR TITLE
Build command cleans static directory, if it exists

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -8,6 +8,7 @@ const npmBin = path.join(cwd, './node_modules/.bin');
 // Production build
 const build = (config = { silent: false }) => {
   cp.execSync(`
+    rm -rf ${cwd}/static &&
     NODE_ENV=production "${npmBin}/webpack" \
       --display-error-details \
       --config \


### PR DESCRIPTION
The build command can remove any unreferenced files from previous builds if any remain in the static directory.